### PR TITLE
Add native Swift/SwiftUI iOS app in ios/

### DIFF
--- a/ios/Aura/AuraApp.swift
+++ b/ios/Aura/AuraApp.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+@main
+struct AuraApp: App {
+    @StateObject private var authService = AuthService()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(authService)
+                .preferredColorScheme(.dark)
+                .onOpenURL { url in
+                    // Handle OAuth callback from Google sign-in
+                    Task {
+                        try? await SupabaseService.shared.client.auth.session(from: url)
+                    }
+                }
+        }
+    }
+}

--- a/ios/Aura/Config.swift
+++ b/ios/Aura/Config.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Fill in your Supabase project credentials.
+/// Get these from your Supabase dashboard → Project Settings → API
+enum Config {
+    /// e.g. "https://xxxxxxxxxxxx.supabase.co"
+    static let supabaseURL = "YOUR_SUPABASE_URL"
+
+    /// The public anon key — safe to include in the app
+    static let supabaseAnonKey = "YOUR_SUPABASE_ANON_KEY"
+}

--- a/ios/Aura/Extensions.swift
+++ b/ios/Aura/Extensions.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Supabase
+
+// MARK: - AnyJSON helpers
+
+extension AnyJSON {
+    /// Returns the string value if this JSON value is a `.string`, otherwise nil.
+    var stringValue: String? {
+        if case .string(let s) = self { return s }
+        return nil
+    }
+}
+
+// MARK: - Binding helpers
+
+import SwiftUI
+
+extension Binding where Value == Bool {
+    /// Creates a Bool binding from an optional — true while the optional is non-nil.
+    static func present<T>(_ optional: Binding<T?>) -> Binding<Bool> {
+        Binding(
+            get: { optional.wrappedValue != nil },
+            set: { if !$0 { optional.wrappedValue = nil } }
+        )
+    }
+}

--- a/ios/Aura/Info.plist
+++ b/ios/Aura/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>Aura</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <!-- Custom URL scheme for OAuth callback -->
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>aura</string>
+            </array>
+        </dict>
+    </array>
+    <!-- Permissions -->
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Allow Aura to access your photos to upload them to your collection.</string>
+    <!-- UI configuration -->
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+    <key>UIRequiresFullScreen</key>
+    <true/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+    <key>UIStatusBarStyle</key>
+    <string>UIStatusBarStyleLightContent</string>
+    <key>UIViewControllerBasedStatusBarAppearance</key>
+    <false/>
+</dict>
+</plist>

--- a/ios/Aura/Models/MediaItem.swift
+++ b/ios/Aura/Models/MediaItem.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+struct MediaItem: Decodable, Identifiable {
+    let id: Int
+    let type: MediaType
+    let url: String
+    let thumbnail: String?
+    let name: String?
+    let price: String?
+    let images: ProductImages?
+
+    enum MediaType: String, Decodable {
+        case image, video
+    }
+
+    struct ProductImages: Decodable {
+        let model1: String?
+    }
+
+    /// Best URL to show as the primary still image
+    var displayImageURL: URL? {
+        let raw = images?.model1 ?? (type == .image ? url : thumbnail) ?? url
+        return URL(string: raw)
+    }
+}
+
+enum FeedMode: Equatable {
+    case afProducts
+    case myPhotos
+}

--- a/ios/Aura/Services/AuthService.swift
+++ b/ios/Aura/Services/AuthService.swift
@@ -1,0 +1,111 @@
+import Foundation
+import AuthenticationServices
+import UIKit
+import Supabase
+
+@MainActor
+final class AuthService: NSObject, ObservableObject {
+    @Published var user: User?
+    @Published var isLoading = true
+
+    private let supabase = SupabaseService.shared.client
+    private var authWebSession: ASWebAuthenticationSession?
+
+    override init() {
+        super.init()
+        Task { await observeAuthChanges() }
+    }
+
+    // MARK: - Auth State
+
+    private func observeAuthChanges() async {
+        for await (_, session) in supabase.auth.authStateChanges {
+            user = session?.user
+            isLoading = false
+            if let user = session?.user {
+                await ensureUserProfile(user: user)
+            }
+        }
+    }
+
+    // MARK: - Sign In
+
+    /// Opens Google OAuth in an in-app browser (ASWebAuthenticationSession).
+    /// The callback URL is handled in AuraApp via .onOpenURL.
+    func signInWithGoogle() async throws {
+        let redirectURL = URL(string: "aura://auth/callback")!
+
+        let oauthURL = try await supabase.auth.signInWithOAuth(
+            provider: .google,
+            redirectTo: redirectURL
+        )
+
+        let callbackURL: URL = try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: oauthURL,
+                callbackURLScheme: "aura"
+            ) { url, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let url {
+                    continuation.resume(returning: url)
+                } else {
+                    continuation.resume(throwing: URLError(.badURL))
+                }
+            }
+            session.prefersEphemeralWebBrowserSession = false
+            session.presentationContextProvider = self
+            self.authWebSession = session
+            session.start()
+        }
+
+        try await supabase.auth.session(from: callbackURL)
+    }
+
+    // MARK: - Sign Out
+
+    func signOut() async throws {
+        try await supabase.auth.signOut()
+    }
+
+    // MARK: - User Profile
+
+    private func ensureUserProfile(user: User) async {
+        struct UserProfile: Encodable {
+            let id: String
+            let username: String
+            let avatar_url: String?
+        }
+
+        let name = user.userMetadata["name"]?.stringValue
+            ?? user.email?.components(separatedBy: "@").first
+            ?? "User"
+        let avatarURL = user.userMetadata["avatar_url"]?.stringValue
+            ?? user.userMetadata["picture"]?.stringValue
+
+        let profile = UserProfile(id: user.id.uuidString, username: name, avatar_url: avatarURL)
+
+        do {
+            try await supabase
+                .from("users")
+                .upsert(profile)
+                .execute()
+        } catch {
+            print("Failed to upsert user profile:", error)
+        }
+    }
+}
+
+// MARK: - ASWebAuthenticationPresentationContextProviding
+
+extension AuthService: ASWebAuthenticationPresentationContextProviding {
+    nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        DispatchQueue.main.sync {
+            UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+                .first { $0.isKeyWindow } ?? ASPresentationAnchor()
+        }
+    }
+}
+

--- a/ios/Aura/Services/MediaService.swift
+++ b/ios/Aura/Services/MediaService.swift
@@ -1,0 +1,97 @@
+import Foundation
+import PhotosUI
+import SwiftUI
+import Supabase
+
+final class MediaService {
+    static let shared = MediaService()
+    private let supabase = SupabaseService.shared.client
+
+    private init() {}
+
+    // MARK: - Fetch
+
+    func fetchProducts() async throws -> [MediaItem] {
+        try await supabase
+            .from("products")
+            .select()
+            .order("id", ascending: true)
+            .execute()
+            .value
+    }
+
+    func fetchUserMedia(userId: String) async throws -> [MediaItem] {
+        try await supabase
+            .from("user_media")
+            .select()
+            .eq("user_id", value: userId)
+            .order("created_at", ascending: false)
+            .execute()
+            .value
+    }
+
+    // MARK: - Upload
+
+    /// Uploads a photo selected from PhotosPicker and inserts metadata into user_media.
+    func uploadPhoto(item: PhotosPickerItem, userId: String) async throws -> String {
+        guard let data = try await item.loadTransferable(type: Data.self) else {
+            throw UploadError.dataLoadFailed
+        }
+
+        guard data.count <= 5 * 1024 * 1024 else {
+            throw UploadError.fileTooLarge
+        }
+
+        let fileName = "\(Int(Date().timeIntervalSince1970)).jpg"
+        let filePath = "\(userId)/\(fileName)"
+
+        _ = try await supabase.storage
+            .from("user-images")
+            .upload(filePath, data: data, options: FileOptions(contentType: "image/jpeg"))
+
+        let publicURL = try supabase.storage
+            .from("user-images")
+            .getPublicURL(path: filePath)
+
+        struct UserMediaInsert: Encodable {
+            let user_id: String
+            let url: String
+            let type: String
+        }
+
+        try await supabase
+            .from("user_media")
+            .insert(UserMediaInsert(user_id: userId, url: publicURL.absoluteString, type: "image"))
+            .execute()
+
+        return publicURL.absoluteString
+    }
+
+    // MARK: - Authenticated Image URL
+
+    /// Returns a 1-hour signed URL for authenticated Supabase Storage images.
+    func signedURL(for url: String) async throws -> URL {
+        guard let filePath = url.components(separatedBy: "/user-images/").last else {
+            throw UploadError.invalidURL
+        }
+        return try await supabase.storage
+            .from("user-images")
+            .createSignedURL(path: filePath, expiresIn: 3600)
+    }
+
+    // MARK: - Errors
+
+    enum UploadError: LocalizedError {
+        case dataLoadFailed
+        case fileTooLarge
+        case invalidURL
+
+        var errorDescription: String? {
+            switch self {
+            case .dataLoadFailed: return "Could not load image data."
+            case .fileTooLarge: return "Image must be smaller than 5 MB."
+            case .invalidURL: return "Invalid storage URL."
+            }
+        }
+    }
+}

--- a/ios/Aura/Services/SupabaseService.swift
+++ b/ios/Aura/Services/SupabaseService.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Supabase
+
+final class SupabaseService {
+    static let shared = SupabaseService()
+
+    let client: SupabaseClient
+
+    private init() {
+        guard let url = URL(string: Config.supabaseURL) else {
+            fatalError("Invalid Supabase URL in Config.swift")
+        }
+        client = SupabaseClient(supabaseURL: url, supabaseKey: Config.supabaseAnonKey)
+    }
+}

--- a/ios/Aura/Views/AuthButtonView.swift
+++ b/ios/Aura/Views/AuthButtonView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct AuthButtonView: View {
+    @EnvironmentObject var auth: AuthService
+    @State private var showMenu = false
+    @State private var errorMessage: String?
+
+    private var avatarURL: URL? {
+        guard let raw = auth.user?.userMetadata["avatar_url"]?.stringValue
+                ?? auth.user?.userMetadata["picture"]?.stringValue
+        else { return nil }
+        return URL(string: raw)
+    }
+
+    var body: some View {
+        Button { showMenu = true } label: {
+            if auth.user != nil {
+                avatarView
+            } else {
+                Text("Sign In")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 7)
+                    .background(.white.opacity(0.2))
+                    .clipShape(Capsule())
+            }
+        }
+        .confirmationDialog("Account", isPresented: $showMenu) {
+            if auth.user != nil {
+                Button("Sign Out", role: .destructive) {
+                    Task { try? await auth.signOut() }
+                }
+            } else {
+                Button("Sign in with Google") {
+                    Task {
+                        do { try await auth.signInWithGoogle() }
+                        catch { errorMessage = error.localizedDescription }
+                    }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            if let email = auth.user?.email {
+                Text(email)
+            }
+        }
+        .alert("Sign-in Error", isPresented: .present($errorMessage), actions: {
+            Button("OK") { errorMessage = nil }
+        }, message: {
+            Text(errorMessage ?? "")
+        })
+    }
+
+    @ViewBuilder
+    private var avatarView: some View {
+        if let url = avatarURL {
+            AsyncImage(url: url) { phase in
+                if case .success(let img) = phase {
+                    img.resizable().scaledToFill()
+                } else {
+                    placeholderAvatar
+                }
+            }
+            .frame(width: 36, height: 36)
+            .clipShape(Circle())
+        } else {
+            placeholderAvatar
+        }
+    }
+
+    private var placeholderAvatar: some View {
+        ZStack {
+            Circle().fill(Color.gray.opacity(0.6))
+            Text(auth.user?.email?.prefix(1).uppercased() ?? "U")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundStyle(.white)
+        }
+        .frame(width: 36, height: 36)
+    }
+}
+

--- a/ios/Aura/Views/ContentView.swift
+++ b/ios/Aura/Views/ContentView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject var auth: AuthService
+    @State private var feedMode: FeedMode = .afProducts
+    @State private var media: [MediaItem] = []
+    @State private var isLoadingMedia = true
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            if auth.isLoading || isLoadingMedia {
+                ProgressView()
+                    .tint(.white)
+                    .scaleEffect(1.5)
+            } else if feedMode == .myPhotos && auth.user == nil {
+                loginPrompt
+            } else {
+                FeedView(media: media)
+            }
+
+            // Overlay controls always on top
+            if !auth.isLoading {
+                overlayControls
+            }
+        }
+        .task(id: feedMode) { await loadMedia() }
+        .task(id: auth.user?.id) { await loadMedia() }
+    }
+
+    // MARK: - Subviews
+
+    private var overlayControls: some View {
+        VStack {
+            HStack(alignment: .center) {
+                // Feed toggle pills
+                HStack(spacing: 6) {
+                    toggleButton("A&F", mode: .afProducts)
+                    toggleButton("My Photos", mode: .myPhotos)
+                }
+
+                Spacer()
+
+                // Auth + Upload buttons
+                HStack(spacing: 8) {
+                    if auth.user != nil && feedMode == .myPhotos {
+                        UploadButtonView { await loadMedia() }
+                    }
+                    AuthButtonView()
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+
+            Spacer()
+        }
+    }
+
+    private func toggleButton(_ label: String, mode: FeedMode) -> some View {
+        Button(label) { feedMode = mode }
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(feedMode == mode ? .white : .white.opacity(0.6))
+            .padding(.horizontal, 14)
+            .padding(.vertical, 7)
+            .background(feedMode == mode ? Color.white.opacity(0.25) : Color.black.opacity(0.4))
+            .clipShape(Capsule())
+    }
+
+    private var loginPrompt: some View {
+        VStack(spacing: 12) {
+            Text("Sign in to view your photos")
+                .font(.title2).bold()
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+            Text("Sign in to upload and view your personal photo collection")
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.6))
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 32)
+    }
+
+    // MARK: - Data Loading
+
+    private func loadMedia() async {
+        isLoadingMedia = true
+        defer { isLoadingMedia = false }
+
+        do {
+            var data: [MediaItem]
+            if feedMode == .afProducts {
+                data = try await MediaService.shared.fetchProducts()
+                data = data.filter { $0.images?.model1 != nil }
+            } else {
+                guard let userId = auth.user?.id.uuidString else {
+                    media = []
+                    return
+                }
+                data = try await MediaService.shared.fetchUserMedia(userId: userId)
+            }
+            media = data.shuffled()
+        } catch {
+            print("Error loading media:", error)
+        }
+    }
+}

--- a/ios/Aura/Views/FeedView.swift
+++ b/ios/Aura/Views/FeedView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct FeedView: View {
+    let media: [MediaItem]
+    @State private var currentID: Int?
+
+    var body: some View {
+        GeometryReader { geo in
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(spacing: 0) {
+                    ForEach(media) { item in
+                        MediaItemView(item: item, isActive: item.id == currentID)
+                            .frame(width: geo.size.width, height: geo.size.height)
+                            .containerRelativeFrame(.vertical)
+                            .id(item.id)
+                    }
+                }
+                .scrollTargetLayout()
+            }
+            .scrollTargetBehavior(.paging)
+            .scrollPosition(id: $currentID)
+            .ignoresSafeArea()
+            .overlay(alignment: .bottom) {
+                if let current = media.first(where: { $0.id == currentID }),
+                   let name = current.name, let price = current.price {
+                    productLink(name: name, price: price, item: current)
+                }
+            }
+        }
+        .onAppear {
+            currentID = media.first?.id
+        }
+        .onChange(of: media) { _, newMedia in
+            currentID = newMedia.first?.id
+        }
+    }
+
+    private func productLink(name: String, price: String, item: MediaItem) -> some View {
+        Button {
+            let query = "Abercrombie and Fitch \(name)"
+                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+            if let url = URL(string: "https://www.google.com/search?q=\(query)") {
+                UIApplication.shared.open(url)
+            }
+        } label: {
+            HStack(spacing: 10) {
+                Text(price)
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundStyle(.white)
+                Text(name)
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white.opacity(0.85))
+                    .lineLimit(1)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(.black.opacity(0.55), in: RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 16)
+            .padding(.bottom, 48)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/ios/Aura/Views/ImageItemView.swift
+++ b/ios/Aura/Views/ImageItemView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct ImageItemView: View {
+    let item: MediaItem
+    @State private var resolvedURL: URL?
+    @State private var isLoading = true
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                Color.black
+
+                if let url = resolvedURL {
+                    AsyncImage(url: url) { phase in
+                        switch phase {
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: geo.size.width, height: geo.size.height)
+                                .clipped()
+                        case .failure:
+                            Image(systemName: "photo")
+                                .foregroundStyle(.white.opacity(0.3))
+                                .font(.system(size: 48))
+                        case .empty:
+                            ProgressView().tint(.white)
+                        @unknown default:
+                            EmptyView()
+                        }
+                    }
+                } else if isLoading {
+                    ProgressView().tint(.white)
+                }
+            }
+        }
+        .task(id: item.url) {
+            await resolveURL()
+        }
+    }
+
+    private func resolveURL() async {
+        isLoading = true
+        if item.url.contains("supabase.co/storage") {
+            resolvedURL = try? await MediaService.shared.signedURL(for: item.url)
+        } else {
+            resolvedURL = item.displayImageURL
+        }
+        isLoading = false
+    }
+}

--- a/ios/Aura/Views/MediaItemView.swift
+++ b/ios/Aura/Views/MediaItemView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct MediaItemView: View {
+    let item: MediaItem
+    let isActive: Bool
+
+    var body: some View {
+        switch item.type {
+        case .video:
+            VideoItemView(item: item, isActive: isActive)
+        case .image:
+            ImageItemView(item: item)
+        }
+    }
+}

--- a/ios/Aura/Views/UploadButtonView.swift
+++ b/ios/Aura/Views/UploadButtonView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import PhotosUI
+
+struct UploadButtonView: View {
+    @EnvironmentObject var auth: AuthService
+    let onComplete: () async -> Void
+
+    @State private var selectedItem: PhotosPickerItem?
+    @State private var isUploading = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        PhotosPicker(selection: $selectedItem, matching: .images) {
+            ZStack {
+                Circle()
+                    .fill(.white.opacity(0.2))
+                    .frame(width: 40, height: 40)
+
+                if isUploading {
+                    ProgressView()
+                        .tint(.white)
+                        .scaleEffect(0.8)
+                } else {
+                    Image(systemName: "camera.fill")
+                        .font(.system(size: 18))
+                        .foregroundStyle(.white)
+                }
+            }
+        }
+        .disabled(isUploading)
+        .onChange(of: selectedItem) { _, item in
+            guard let item else { return }
+            Task { await upload(item: item) }
+        }
+        .alert("Upload Error", isPresented: .present($errorMessage)) {
+            Button("OK") { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private func upload(item: PhotosPickerItem) async {
+        guard let userId = auth.user?.id.uuidString else { return }
+        isUploading = true
+        defer {
+            isUploading = false
+            selectedItem = nil
+        }
+
+        do {
+            _ = try await MediaService.shared.uploadPhoto(item: item, userId: userId)
+            await onComplete()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ios/Aura/Views/VideoItemView.swift
+++ b/ios/Aura/Views/VideoItemView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+import AVKit
+
+struct VideoItemView: View {
+    let item: MediaItem
+    let isActive: Bool
+
+    @State private var player: AVPlayer?
+    @State private var isPaused = false
+
+    var body: some View {
+        ZStack {
+            Color.black
+
+            if let player {
+                VideoPlayer(player: player)
+                    .disabled(true)           // We handle taps ourselves below
+                    .ignoresSafeArea()
+
+                // Custom tap to play/pause
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture { togglePlayback() }
+
+                if isPaused {
+                    Image(systemName: "pause.fill")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.white.opacity(0.8))
+                        .allowsHitTesting(false)
+                }
+            }
+        }
+        .onAppear { setupPlayer() }
+        .onDisappear { teardownPlayer() }
+        .onChange(of: isActive) { _, active in
+            if active {
+                player?.seek(to: .zero)
+                player?.play()
+                isPaused = false
+            } else {
+                player?.pause()
+                player?.seek(to: .zero)
+                isPaused = false
+            }
+        }
+    }
+
+    private func setupPlayer() {
+        guard let url = URL(string: item.url) else { return }
+        let avPlayer = AVPlayer(url: url)
+        avPlayer.isMuted = true
+
+        // Loop video
+        NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: avPlayer.currentItem,
+            queue: .main
+        ) { _ in
+            avPlayer.seek(to: .zero)
+            avPlayer.play()
+        }
+
+        player = avPlayer
+        if isActive {
+            avPlayer.play()
+        }
+    }
+
+    private func teardownPlayer() {
+        player?.pause()
+        player = nil
+    }
+
+    private func togglePlayback() {
+        guard let player else { return }
+        if isPaused {
+            player.play()
+        } else {
+            player.pause()
+        }
+        isPaused.toggle()
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,0 +1,33 @@
+name: Aura
+options:
+  bundleIdPrefix: com.ayush29feb
+  deploymentTarget:
+    iOS: "17.0"
+  defaultConfig: Debug
+
+packages:
+  supabase-swift:
+    url: https://github.com/supabase/supabase-swift
+    from: 2.5.1
+
+targets:
+  Aura:
+    type: application
+    platform: iOS
+    sources:
+      - path: Aura
+    info:
+      path: Aura/Info.plist
+    dependencies:
+      - package: supabase-swift
+        product: Supabase
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.ayush29feb.aura
+        SWIFT_VERSION: "5.9"
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: ""
+        TARGETED_DEVICE_FAMILY: "1"
+        IPHONEOS_DEPLOYMENT_TARGET: "17.0"
+        SUPPORTED_PLATFORMS: iphoneos iphonesimulator
+        SUPPORTS_MACCATALYST: "NO"


### PR DESCRIPTION
Architecture:
- SwiftUI with iOS 17 APIs (scrollTargetBehavior, scrollPosition, containerRelativeFrame)
- Vertical paged feed via ScrollView + .scrollTargetBehavior(.paging) — native TikTok feel
- supabase-swift v2 for database, auth, and storage
- ASWebAuthenticationSession for in-app Google OAuth browser

File structure (ios/Aura/):
- AuraApp.swift       — @main entry, handles onOpenURL OAuth callback
- Config.swift        — Supabase credentials placeholder
- Extensions.swift    — AnyJSON.stringValue helper, Binding.present utility
- Models/MediaItem.swift     — Decodable model matching Supabase schema
- Services/SupabaseService.swift  — Singleton SupabaseClient
- Services/AuthService.swift — ObservableObject: Google OAuth, sign-out, user profile upsert
- Services/MediaService.swift — fetch products/user media, upload via PhotosPickerItem, signed URLs
- Views/ContentView.swift    — Root: feed toggle, auth/upload buttons, media loading
- Views/FeedView.swift       — Paged scroll feed with product link overlay
- Views/MediaItemView.swift  — Dispatches to ImageItemView or VideoItemView
- Views/ImageItemView.swift  — AsyncImage with signed URL for Supabase storage images
- Views/VideoItemView.swift  — AVKit VideoPlayer with looping, mute, tap to pause
- Views/AuthButtonView.swift — Avatar/sign-in button with confirmationDialog
- Views/UploadButtonView.swift — PhotosPicker camera button with upload progress
- project.yml                — XcodeGen config (run `xcodegen generate` to create .xcodeproj)

https://claude.ai/code/session_01MJnhC9266h3TAF234MxHR4